### PR TITLE
Add shuffle and loop player controls

### DIFF
--- a/src/components/Player/Player.jsx
+++ b/src/components/Player/Player.jsx
@@ -4,7 +4,22 @@ import { PlayerContext } from '../../context/PlayerContext'
 
 const Player = () => {
 
-    const { track, playStatus, play, pause, previous, next, seekBar, seekBg, seekSong, time } = useContext(PlayerContext);
+    const {
+        track,
+        playStatus,
+        play,
+        pause,
+        previous,
+        next,
+        seekBar,
+        seekBg,
+        seekSong,
+        time,
+        isShuffling,
+        isLooping,
+        toggleShuffle,
+        toggleLoop
+    } = useContext(PlayerContext);
 
     return (
         <div className='h-[10%] bg-black flex justify-between items-center text-white px-4'>
@@ -17,14 +32,26 @@ const Player = () => {
             </div>
             <div className='flex flex-col items-center gap-1 m-auto'>
                 <div className='flex gap-4'>
-                    <img className='w-4 cursor-pointer' src={assets.shuffle_icon} alt="" />
+                    <img
+                        className='w-4 cursor-pointer'
+                        onClick={toggleShuffle}
+                        style={{ opacity: isShuffling ? 1 : 0.5 }}
+                        src={assets.shuffle_icon}
+                        alt=""
+                    />
                     <img className='w-4 cursor-pointer' onClick={previous} src={assets.prev_icon} alt="" />
                     {playStatus
                         ? <img className='w-4 cursor-pointer' onClick={pause} src={assets.pause_icon} alt="" />
                         : <img className='w-4 cursor-pointer' onClick={play} src={assets.play_icon} alt="" />
                     }
                     <img className='w-4 cursor-pointer' onClick={next} src={assets.next_icon} alt="" />
-                    <img className='w-4 cursor-pointer' src={assets.loop_icon} alt="" />
+                    <img
+                        className='w-4 cursor-pointer'
+                        onClick={toggleLoop}
+                        style={{ opacity: isLooping ? 1 : 0.5 }}
+                        src={assets.loop_icon}
+                        alt=""
+                    />
                 </div>
                 <div className='flex items-center gap-5'>
                     <p>{time.currentTime.minute}:{time.currentTime.second}</p>

--- a/src/context/PlayerContext.jsx
+++ b/src/context/PlayerContext.jsx
@@ -11,6 +11,8 @@ const PlayerContextProvider = (props) => {
     
     const [track, setTrack] = useState(songsData[0]);
     const [playStatus, setPlayStatus] = useState(false)
+    const [isShuffling, setIsShuffling] = useState(false);
+    const [isLooping, setIsLooping] = useState(false);
     const [time, setTime] = useState({
         currentTime: {
             second: 0,
@@ -31,6 +33,20 @@ const PlayerContextProvider = (props) => {
     const pause = () => {
         audioRef.current.pause();
         setPlayStatus(false);
+    }
+
+    const toggleShuffle = () => {
+        setIsShuffling(prev => !prev);
+    }
+
+    const toggleLoop = () => {
+        setIsLooping(prev => {
+            const newState = !prev;
+            if (audioRef.current) {
+                audioRef.current.loop = newState;
+            }
+            return newState;
+        });
     }
 
     const previous = async () => {
@@ -80,7 +96,24 @@ const PlayerContextProvider = (props) => {
     }, [audioRef])
 
     const contextValue = {
-        audioRef, track, setTrack, playStatus, setPlayStatus, next, previous, play, pause, playWithId, seekBar, seekBg, seekSong, time
+        audioRef,
+        track,
+        setTrack,
+        playStatus,
+        setPlayStatus,
+        next,
+        previous,
+        play,
+        pause,
+        playWithId,
+        seekBar,
+        seekBg,
+        seekSong,
+        time,
+        isShuffling,
+        isLooping,
+        toggleShuffle,
+        toggleLoop
     }
 
     return (


### PR DESCRIPTION
## Summary
- support shuffle and loop toggling in player context
- expose shuffle and loop controls in Player UI

## Testing
- `npm run lint` *(fails: 27 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840084a2148832781d9868cf69a0530