### PR TITLE
Add volume state and controls

### DIFF
--- a/src/components/Player/Player.jsx
+++ b/src/components/Player/Player.jsx
@@ -4,7 +4,11 @@ import { PlayerContext } from '../../context/PlayerContext'
 
 const Player = () => {
 
-    const { track, playStatus, play, pause, previous, next, seekBar, seekBg, seekSong, time } = useContext(PlayerContext);
+    const { track, playStatus, play, pause, previous, next, seekBar, seekBg, seekSong, time, volume, setVolume } = useContext(PlayerContext);
+
+    const handlePlays = () => console.log('plays icon');
+    const handleMic = () => console.log('mic icon');
+    const handleQueue = () => console.log('queue icon');
 
     return (
         <div className='h-[10%] bg-black flex justify-between items-center text-white px-4'>
@@ -35,14 +39,20 @@ const Player = () => {
                 </div>
             </div>
             <div className='hidden items-center gap-2 opacity-75 lg:flex'>
-                <img className='w-4' src={assets.plays_icon} alt="" />
-                <img className='w-4' src={assets.mic_icon} alt="" />
-                <img className='w-4' src={assets.queue_icon} alt="" />
+                <img className='w-4 cursor-pointer' onClick={handlePlays} src={assets.plays_icon} alt='' />
+                <img className='w-4 cursor-pointer' onClick={handleMic} src={assets.mic_icon} alt='' />
+                <img className='w-4 cursor-pointer' onClick={handleQueue} src={assets.queue_icon} alt='' />
                 <img className='w-4' src={assets.speaker_icon} alt="" />
                 <img className='w-4' src={assets.volume_icon} alt="" />
-                <div className='w-20 bg-slate-50'>
-                    <hr className='h-1 bg-slate-50 rounded' />
-                </div>
+                <input
+                    className='w-20'
+                    type='range'
+                    min='0'
+                    max='1'
+                    step='0.01'
+                    value={volume}
+                    onChange={(e) => setVolume(parseFloat(e.target.value))}
+                />
                 <img className='w-4' src={assets.mini_player_icon} alt="" />
                 <img className='w-4' src={assets.zoom_icon} alt="" />
             </div>

--- a/src/context/PlayerContext.jsx
+++ b/src/context/PlayerContext.jsx
@@ -11,6 +11,14 @@ const PlayerContextProvider = (props) => {
     
     const [track, setTrack] = useState(songsData[0]);
     const [playStatus, setPlayStatus] = useState(false)
+    const [volume, setVolumeState] = useState(0.1);
+
+    const setVolume = (vol) => {
+        setVolumeState(vol);
+        if (audioRef.current) {
+            audioRef.current.volume = vol;
+        }
+    };
     const [time, setTime] = useState({
         currentTime: {
             second: 0,
@@ -24,7 +32,7 @@ const PlayerContextProvider = (props) => {
 
     const play = () => {
         audioRef.current.play();
-        audioRef.current.volume = 0.1;
+        audioRef.current.volume = volume;
         setPlayStatus(true);
     }
 
@@ -57,16 +65,22 @@ const PlayerContextProvider = (props) => {
         setPlayStatus(true);
     }
 
-    const seekSong = async (e) => {
+      const seekSong = async (e) => {
         audioRef.current.currentTime = ((e.nativeEvent.offsetX / seekBg.current.offsetWidth) * audioRef.current.duration);
-    };
+      };
 
-    useEffect(() => {
-        setTimeout(() => {
-            audioRef.current.ontimeupdate = (e) => {
-                seekBar.current.style.width = (Math.floor(audioRef.current.currentTime * 100 / audioRef.current.duration)) + "%";
-                setTime({
-                    currentTime: {
+      useEffect(() => {
+          if (audioRef.current) {
+              audioRef.current.volume = volume;
+          }
+      }, [volume]);
+
+      useEffect(() => {
+          setTimeout(() => {
+              audioRef.current.ontimeupdate = (e) => {
+                  seekBar.current.style.width = (Math.floor(audioRef.current.currentTime * 100 / audioRef.current.duration)) + "%";
+                  setTime({
+                      currentTime: {
                         second: Math.floor(audioRef.current.currentTime % 60),
                         minute: Math.floor(audioRef.current.currentTime / 60)
                     },
@@ -80,7 +94,22 @@ const PlayerContextProvider = (props) => {
     }, [audioRef])
 
     const contextValue = {
-        audioRef, track, setTrack, playStatus, setPlayStatus, next, previous, play, pause, playWithId, seekBar, seekBg, seekSong, time
+        audioRef,
+        track,
+        setTrack,
+        playStatus,
+        setPlayStatus,
+        next,
+        previous,
+        play,
+        pause,
+        playWithId,
+        seekBar,
+        seekBg,
+        seekSong,
+        time,
+        volume,
+        setVolume,
     }
 
     return (


### PR DESCRIPTION
## Summary
- add `volume` state and setter in PlayerContext
- sync audio volume with state changes
- expose volume and setVolume via PlayerContext
- connect volume slider in Player component
- add placeholder handlers for plays, mic, and queue icons

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6840084b33088327ae698cd1c4bb2877