### PR TITLE
Remove setTimeout from player context effect

### DIFF
--- a/src/context/PlayerContext.jsx
+++ b/src/context/PlayerContext.jsx
@@ -62,22 +62,28 @@ const PlayerContextProvider = (props) => {
     };
 
     useEffect(() => {
-        setTimeout(() => {
-            audioRef.current.ontimeupdate = (e) => {
-                seekBar.current.style.width = (Math.floor(audioRef.current.currentTime * 100 / audioRef.current.duration)) + "%";
-                setTime({
-                    currentTime: {
-                        second: Math.floor(audioRef.current.currentTime % 60),
-                        minute: Math.floor(audioRef.current.currentTime / 60)
-                    },
-                    totalTime: {
-                        second: Math.floor(audioRef.current.duration % 60),
-                        minute: Math.floor(audioRef.current.duration / 60)
-                    }
-                })
-            }
-        }, 1000);
-    }, [audioRef])
+        const audioEl = audioRef.current;
+        if (!audioEl) return;
+
+        const handleTimeUpdate = () => {
+            seekBar.current.style.width = (Math.floor(audioEl.currentTime * 100 / audioEl.duration)) + "%";
+            setTime({
+                currentTime: {
+                    second: Math.floor(audioEl.currentTime % 60),
+                    minute: Math.floor(audioEl.currentTime / 60)
+                },
+                totalTime: {
+                    second: Math.floor(audioEl.duration % 60),
+                    minute: Math.floor(audioEl.duration / 60)
+                }
+            })
+        };
+
+        audioEl.ontimeupdate = handleTimeUpdate;
+        return () => {
+            audioEl.ontimeupdate = null;
+        };
+    }, [])
 
     const contextValue = {
         audioRef, track, setTrack, playStatus, setPlayStatus, next, previous, play, pause, playWithId, seekBar, seekBg, seekSong, time


### PR DESCRIPTION
## Summary
- simplify player context `useEffect`
- attach `ontimeupdate` directly and clean up on unmount

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint couldn't find config and reports many errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840084ccb4883278ac09a0ed066a030