### PR TITLE
Add time formatting helper

### DIFF
--- a/src/components/Player/Player.jsx
+++ b/src/components/Player/Player.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { assets } from '../../assets/assets'
 import { PlayerContext } from '../../context/PlayerContext'
+import { formatTime } from '../../utils/formatTime'
 
 const Player = () => {
 
@@ -27,11 +28,11 @@ const Player = () => {
                     <img className='w-4 cursor-pointer' src={assets.loop_icon} alt="" />
                 </div>
                 <div className='flex items-center gap-5'>
-                    <p>{time.currentTime.minute}:{time.currentTime.second}</p>
+                    <p>{formatTime(time.currentTime.minute, time.currentTime.second)}</p>
                     <div onClick={seekSong} ref={seekBg} className='w-[60vw] max-w-[500px] bg-gray-300 rounded-full cursor-pointer'>
                         <hr ref={seekBar} className='h-1 border-none w-0 bg-green-800 rounded-full' />
                     </div>
-                    <p>{time.totalTime.minute}:{time.totalTime.second}</p>
+                    <p>{formatTime(time.totalTime.minute, time.totalTime.second)}</p>
                 </div>
             </div>
             <div className='hidden items-center gap-2 opacity-75 lg:flex'>

--- a/src/utils/formatTime.js
+++ b/src/utils/formatTime.js
@@ -1,0 +1,5 @@
+export function formatTime(min, sec) {
+  const m = String(min).padStart(2, '0');
+  const s = String(sec).padStart(2, '0');
+  return `${m}:${s}`;
+}


### PR DESCRIPTION
## Summary
- add a `formatTime` helper for zero‑padding minute and second values
- use `formatTime` in `Player` component for the current and total time display

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68400acc6dbc832781e32b40b94875b9