### PR TITLE
Fix PlayerContext seekSong function

### DIFF
--- a/src/context/PlayerContext.jsx
+++ b/src/context/PlayerContext.jsx
@@ -73,9 +73,9 @@ const PlayerContextProvider = (props) => {
         setPlayStatus(true);
     }
 
-    const seekSong = async (e) => {
-        audioRef.current.currentTime = ((e.nativeEvent.offsetX / seekBg.current.offsetWidth) * audioRef.current.duration);
-    };
+    function seekSong(e) {
+        audioRef.current.currentTime = (e.nativeEvent.offsetX / seekBg.current.offsetWidth) * audioRef.current.duration;
+    }
 
     useEffect(() => {
         const audioEl = audioRef.current;


### PR DESCRIPTION
## Summary
- convert `seekSong` from an async arrow function to a regular function

## Testing
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_68400da4e1208327a4652b23bb457b6a