### PR TITLE
Fix lint script by specifying eslintrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint --config .eslintrc.cjs . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary
- update lint script to explicitly use `.eslintrc.cjs`

## Testing
- `npm install`
- `npm run lint` *(fails: 27 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684019347bc48327a61b5424da44f3c4