### PR TITLE
Fix NaN time when switching tracks

### DIFF
--- a/src/context/PlayerContext.jsx
+++ b/src/context/PlayerContext.jsx
@@ -88,7 +88,8 @@ const PlayerContextProvider = (props) => {
         const audioEl = audioRef.current;
         if (!audioEl) return;
 
-        const handleTimeUpdate = () => {
+    const handleTimeUpdate = () => {
+            if (!Number.isFinite(audioEl.duration)) return;
             seekBar.current.style.width = (Math.floor(audioEl.currentTime * 100 / audioEl.duration)) + "%";
             setTime({
                 currentTime: {
@@ -111,6 +112,26 @@ const PlayerContextProvider = (props) => {
             audioEl.ontimeupdate = null;
         };
     }, [])
+
+    useEffect(() => {
+        const audioEl = audioRef.current;
+        if (!audioEl) return;
+        setTime({
+            currentTime: { second: 0, minute: 0 },
+            totalTime: { second: 0, minute: 0 }
+        });
+        const handleMetadata = () => {
+            setTime(prev => ({
+                ...prev,
+                totalTime: {
+                    second: Math.floor(audioEl.duration % 60),
+                    minute: Math.floor(audioEl.duration / 60)
+                }
+            }));
+        };
+        audioEl.addEventListener('loadedmetadata', handleMetadata);
+        return () => audioEl.removeEventListener('loadedmetadata', handleMetadata);
+    }, [track])
 
     const contextValue = {
         audioRef,

--- a/src/utils/formatTime.js
+++ b/src/utils/formatTime.js
@@ -1,5 +1,7 @@
 export function formatTime(min, sec) {
-  const m = String(min).padStart(2, '0');
-  const s = String(sec).padStart(2, '0');
+  const mm = Number.isFinite(min) ? min : 0;
+  const ss = Number.isFinite(sec) ? sec : 0;
+  const m = String(mm).padStart(2, '0');
+  const s = String(ss).padStart(2, '0');
   return `${m}:${s}`;
 }


### PR DESCRIPTION
## Summary
- sanitize minute & second inputs in `formatTime`
- guard `handleTimeUpdate` against missing duration
- reset time and fetch metadata on track changes

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402d670c3c8327aa3f8a8c2b8b3b37